### PR TITLE
Add working and geographical relationships

### DIFF
--- a/src/renderer/components/Cytoscape/stylesheets.js
+++ b/src/renderer/components/Cytoscape/stylesheets.js
@@ -34,6 +34,18 @@ export const defaultEntityColours = [
     },
   },
   {
+    selector: 'edge[type = "working"]',
+    style: {
+      'lineColor': theme.palette.red,
+    },
+  },
+  {
+    selector: 'edge[type = "geographical"]',
+    style: {
+      'lineColor': theme.palette.neutralSecondaryAlt,
+    },
+  },
+  {
     selector: 'node[type = "person"]',
     style: {
       'background-color': theme.palette.blue,

--- a/src/renderer/components/Legend.js
+++ b/src/renderer/components/Legend.js
@@ -14,6 +14,8 @@ const edges = [
   { glyph: 'line', type: 'edge', label: 'financial', color: theme.palette.greenLight },
   { glyph: 'line', type: 'edge', label: 'business', color: theme.palette.tealLight },
   { glyph: 'line', type: 'edge', label: 'ownership', color: theme.palette.magentaLight },
+  { glyph: 'line', type: 'edge', label: 'working', color: theme.palette.red },
+  { glyph: 'line', type: 'edge', label: 'geographical', color: theme.palette.neutralSecondaryAlt },
 ];
 
 const nodes = [

--- a/src/renderer/components/VisualisationScreen/Panels/CreateEdgesPanel.js
+++ b/src/renderer/components/VisualisationScreen/Panels/CreateEdgesPanel.js
@@ -33,6 +33,8 @@ const AddEdgePanel = ({ isOpen, onDismiss }) => {
             { key: 'financial', text: 'Financial Relationship'},
             { key: 'business', text: 'Business Relationship'},
             { key: 'ownership', text: 'Ownership Relationship'},
+            { key: 'working', text: 'Working Relationship'},
+            { key: 'geographical', text: 'Geographical Relationship'},
           ]}
         />
       </Stack>

--- a/src/renderer/components/VisualisationScreen/Panels/RelationshipsPresetPanel.js
+++ b/src/renderer/components/VisualisationScreen/Panels/RelationshipsPresetPanel.js
@@ -45,6 +45,8 @@ const RelationshipsPresetPanel = ({ isOpen, onDismiss }) => {
         <Checkbox name="financial" label="Financial" checked={isChecked('financial')} onChange={onChange} />
         <Checkbox name="business" label="Business" checked={isChecked('business')} onChange={onChange} />
         <Checkbox name="ownership" label="Ownership" checked={isChecked('ownership')} onChange={onChange} />
+        <Checkbox name="working" label="Working" checked={isChecked('working')} onChange={onChange} />
+        <Checkbox name="geographical" label="Geographical" checked={isChecked('geographical')} onChange={onChange} />
       </Stack>
     </Panel>
   );


### PR DESCRIPTION
> 1. In the ‘Add Relationships’ section can we add – ‘Working Relationship’. After working
through a few cases with the software, we didn&#39;t think it fully captured the
relationship of two employees within the same business, or between an employee
and the organisation for which they work. Business relationship we’ll define as a
formal and external relationship from one person or business to a different business
or person within a different business. There is of course overlap with financial
relationship but for that we had in mine relationships that involve purely financial
transactions e.g. a payment from one person or business to another person or
business. We’ll define all these clearly in the handbook.
> 2. In the ‘Add Relationships’ section can we also add a relationship that links locations
e.g. ‘Geographical Relationship’. As we’ll be having multiple layers of modes/nodes it
would be good to have an option that links a place (e.g. playground) to a person or a
resource (to say, for example, that X hides drugs in the playground).

Chose red and grey for the colours, that may need adjusting.